### PR TITLE
Example of a Button component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,20 +2,21 @@
 
 import Image from "next/image";
 import { useEffect, useState } from "react";
+import { ButtonLink, ButtonStyles } from '../components/Button';
+
+// Function to calculate the Starfleet date
+const calculateStarfleetDate = () => {
+  const baseDate = new Date("1987-07-15T00:00:00Z").getTime(); // Base timestamp in milliseconds
+  const currentDate = Date.now(); // Current timestamp in milliseconds
+  const elapsedSeconds = (currentDate - baseDate) / 1000; // Elapsed time in seconds
+
+  const formattedDate = (elapsedSeconds / 3155.76 + 410000) / 10;
+  return formattedDate.toFixed(2); // Format to 2 decimal places
+};
 
 export default function Home() {
   // State to hold the calculated stardate
   const [starfleetDate, setStarfleetDate] = useState<string>("");
-
-  // Function to calculate the Starfleet date
-  const calculateStarfleetDate = () => {
-    const baseDate = new Date("1987-07-15T00:00:00Z").getTime(); // Base timestamp in milliseconds
-    const currentDate = Date.now(); // Current timestamp in milliseconds
-    const elapsedSeconds = (currentDate - baseDate) / 1000; // Elapsed time in seconds
-
-    const formattedDate = (elapsedSeconds / 3155.76 + 410000) / 10;
-    return formattedDate.toFixed(2); // Format to 2 decimal places
-  };
 
   // UseEffect hook to calculate the stardate when the component mounts
   useEffect(() => {
@@ -37,22 +38,8 @@ export default function Home() {
         <p>Welcome to the Library and Computer Access Retrieval System</p>
 
         <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:min-w-44"
-            href=""
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Access
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:min-w-44"
-            href=""
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Credits
-          </a>
+          <ButtonLink path="">Access</ButtonLink>
+          <ButtonLink path="" variant={ButtonStyles.SECONDARY}>Credits</ButtonLink>
         </div>
       </main>
       

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,59 @@
+const enum ButtonType {
+    ACTION = "action",
+    LINK = "link"
+};
+
+export const enum ButtonStyles {
+    PRIMARY = "PRIMARY",
+    SECONDARY = "SECONDARY"
+};
+
+type CommonButtonProps = {
+    variant?: ButtonStyles;
+}
+
+type ActionButtonProps = {
+    onClick: () => void;
+} & CommonButtonProps;
+
+type LinkButtonProps = {
+    path: string;
+} & CommonButtonProps;
+
+type BaseButtonProps = {
+    buttonType: ButtonType
+} & (ActionButtonProps | LinkButtonProps);
+
+const buttonStyleMap = {
+    [ButtonStyles.PRIMARY]: "bg-foreground text-background border-transparent",
+    [ButtonStyles.SECONDARY]: "border-black/[.08] dark:border-white/[.145]",
+};
+
+const getCommonProps = (props: BaseButtonProps) => {
+    const style = props.variant ?? ButtonStyles.PRIMARY;
+    return {
+        className: [
+            "rounded-full border border-solid transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:min-w-44",
+            buttonStyleMap[style]
+        ].join(" "),
+    };
+}
+
+export const ButtonLink: (props: React.PropsWithChildren<LinkButtonProps>) => React.ReactNode = (props) => {
+    const commonProps = getCommonProps({ ...props, buttonType: ButtonType.LINK });
+
+    return <a
+        {...commonProps}
+        href={props.path}
+        target="_blank"
+        rel="noopener noreferrer"
+    >{ props.children }</a>;
+};
+
+export const ButtonAction: (props: React.PropsWithChildren<ActionButtonProps>) => React.ReactNode = (props) => {
+    const commonProps = getCommonProps({ ...props, buttonType: ButtonType.ACTION });
+
+    return <span {...commonProps} onClick={props.onClick}>
+        { props.children }
+    </span>
+};


### PR DESCRIPTION
This pull request introduces a Button component as an example of a relatively complex React component. There is no NextJS code to consider in this pull request, everything here is some combination of JavaScript, TypeScript, React and Tailwind.

This actually contains two components, which could be separated out if they got too unwieldy. One is a `ButtonLink`, used for when routing to another URL/page. The other is a `ButtonAction` for performing actions on the current page. Both should be visually identical, but have different HTML for their use cases and some native accessibility differences that aren't directly visible.

At the top of the Button file, we define a bunch of TypeScript types. enums are just a collection of values, key/value map style. e.g. we have a collection of button types that relate to the two types we just described, and two "styles" of button that represent the appearance of the buttons on your page. I called them Primary/Secondary to avoid naming them after specific colours.

Each Button component has a set of "props", i.e. properties, i.e. the controls that you can manipulate from the outside. I defined some "common" ones that both the components support (i.e. the style), and some specific ones that don't apply to the other (an action can't have a url, for example).

With all the shapes defined, the components themselves are pretty straightforward. A helper function does the common logic for both components, and then each component function adds the unique ones for the variant. There's a small bit of TypeScript magic with `PropsWithChildren`, which is just a React helper to add a `children` prop to your component, which itself lets you say that your component can have more stuff nested inside it. We use that nested stuff for the button content.

Hopefully this overdocumentation is useful! You don't have to accept this, I just thought it might be interesting to you. 🙂 